### PR TITLE
Fix issues #44 and #52

### DIFF
--- a/dcrtxmatcher.go
+++ b/dcrtxmatcher.go
@@ -86,7 +86,7 @@ func run(ctx context.Context) error {
 			err := http.ListenAndServe(intf, nil)
 			if err != nil {
 				log.Errorf("Can not start server: %v", err)
-				return
+				os.Exit(1)
 			}
 		}()
 	}


### PR DESCRIPTION
The PR fix following issues:
https://github.com/raedahgroup/dcrtxmatcher/issues/52:
- Check error message to log detail message of disconnect (from client or server)
https://github.com/raedahgroup/dcrtxmatcher/issues/44:
- Os.exit when port already bound.